### PR TITLE
Add/dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+
+COPY ["requirements.txt", "/usr/src/"]
+
+WORKDIR /usr/src
+
+RUN pip3 install -r requirements.txt
+
+COPY [".", "/usr/src/"]
+
+ENTRYPOINT ["python3", "ctfr.py"]
+
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -54,5 +54,25 @@ python3 ctfr.py -d facebook.com -o /home/shei/subdomains_fb.txt
 </p>
 
 
+### Running with Docker
+
+For those of you that can't run python natively, you may use the unwavering whale. Build your image:
+
+```
+docker build -t ctfr .
+```
+
+And just run it!
+
+```
+docker run --rm ctfr -d starbucks.com
+```
+
+For keeping output files, just mount a volume. E.g.:
+
+```
+docker run --rm -v ${PWD}:/usr/ ctfr -d starbucks.com -o subdomains_sb.txt
+```
+
 ## Author
 * *Sheila A. Berta - [(@UnaPibaGeek)](https://www.twitter.com/UnaPibaGeek).*


### PR DESCRIPTION
For those of us that can't run python natively :)

Default command is `--help` so running a container just spits out the help info.

Running the tool is just running the container with the appropriate parameters, e.g.:

```
docker run --rm ctfr -d ekoparty.org
```

For keeping output files, just mount a volume. E.g.:

```
docker run --rm -v ${PWD}:/usr/src ctfr -d ekoparty.org -o subdomains_eko.txt
```
