### PR TITLE
Added link to optimized Docker image on Docker Hub in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $ python3 ctfr.py -d facebook.com -o /home/shei/subdomains_fb.txt
 ```
 
 ### With Docker
-If you want to use it without installing it to your computer, you can use [this lightweight (97.8MB) Docker image](https://hub.docker.com/r/johnpaulada/ctfr/).
+I think it's a little bit crazy to use Docker for running such a little python script, but if you want to do it anyway, you can download [this lightweight (97.8MB) Docker image](https://hub.docker.com/r/johnpaulada/ctfr/) made by John Paulada.
 
 The instructions are there.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ $ python3 ctfr.py -d starbucks.com
 $ python3 ctfr.py -d facebook.com -o /home/shei/subdomains_fb.txt
 ```
 
+### With Docker
+If you want to use it without installing it to your computer, you can use [this lightweight (97.8MB) Docker image](https://hub.docker.com/r/johnpaulada/ctfr/).
+
+The instructions are there.
 
 ## Screenshots
 <p align="center">


### PR DESCRIPTION
## What I did
I created a lightweight _(97.8MB)_ Docker image for this and pushed it to Docker Hub.
I added the link to the Docker image on Docker Hub.
The instructions are there so it doesn't fill up too much space on the README.

### Dockerfile code
```dockerfile
FROM python:latest AS build-env
WORKDIR /app
RUN git clone https://github.com/UnaPibaGeek/ctfr.git \
        && cd ctfr \
        && pip3 install -r requirements.txt -t .

FROM python:3-alpine
COPY --from=build-env /app/ctfr /app
WORKDIR /app
ENTRYPOINT ["python3", "/app/ctfr.py"]
CMD ["--help"]
```

### Github Repo
[ctfr-docker-image](https://github.com/johnpaulada/ctfr-docker-image)

### Screenshot of the Docker Hub page:
![screenshot-2018-3-9 johnpaulada ctfr - docker hub 1](https://user-images.githubusercontent.com/8457470/37190293-07decd3c-2394-11e8-860f-ffccbeab5542.png)

### Usage Screencast
[![asciicast](https://asciinema.org/a/167914.png)](https://asciinema.org/a/167914)