### PR TITLE
Remove f.close() since is not necesary

### DIFF
--- a/ctfr.py
+++ b/ctfr.py
@@ -43,7 +43,7 @@ def clear_url(target):
 def save_subdomains(subdomain,output_file):
 	with open(output_file,"a") as f:
 		f.write(subdomain + '\n')
-		f.close()
+		
 
 def main():
 	banner()


### PR DESCRIPTION
Hola!

Me di cuenta que usando la sentencia `with` no es necesario cerrar el archivo, ya que precisamente su función es quitarle esa responsabilidad al programador. Quizá estoy equivocada, y realmente no afecta en nada al funcionamiento, en ese caso lo siento mucho! 

